### PR TITLE
Add apps to home screen

### DIFF
--- a/LCAppDelegate.m
+++ b/LCAppDelegate.m
@@ -16,10 +16,7 @@
     _window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     _window.rootViewController = _rootViewController;
     [_window makeKeyAndVisible];
-    
-    if ([launchOptions objectForKey:@"UIApplicationLaunchOptionsURLKey"]) {
-        _window.alpha = 0.0;
-    }
+
     return YES;
 }
 

--- a/LCAppDelegate.m
+++ b/LCAppDelegate.m
@@ -5,6 +5,7 @@
 @implementation LCAppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    
     UIViewController *viewController;
     if ([NSBundle.mainBundle.executablePath.lastPathComponent isEqualToString:@"JITLessSetup"]) {
         viewController = [[LCJITLessSetupViewController alloc] init];
@@ -15,7 +16,35 @@
     _window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     _window.rootViewController = _rootViewController;
     [_window makeKeyAndVisible];
+    
+    if ([launchOptions objectForKey:@"UIApplicationLaunchOptionsURLKey"]) {
+        _window.alpha = 0.0;
+    }
     return YES;
 }
+
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
+    // Parse the URL
+    NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+    NSArray *queryItems = urlComponents.queryItems;
+    NSString *appName = nil;
+
+    for (NSURLQueryItem *item in queryItems) {
+        if ([item.name isEqualToString:@"exec"]) {
+            appName = item.value;
+        }
+    }
+    
+    // Check the path of the URL and call the appropriate function
+    if ([urlComponents.host isEqualToString:@"launchapp"]) {
+        [NSUserDefaults.standardUserDefaults setObject:appName forKey:@"selected"];
+        exit(0);
+    } else if ([urlComponents.host isEqualToString:@"open"]) {
+        exit(0);
+    }
+
+    return YES;
+}
+
 
 @end

--- a/LCRootViewController.m
+++ b/LCRootViewController.m
@@ -624,6 +624,20 @@ static void patchExecSlice(const char *path, struct mach_header_64 *header) {
                 NSString *url = [NSString stringWithFormat:@"shareddocuments://%@/Data/Application/%@", self.docPath, appInfo.dataUUID];
                 [UIApplication.sharedApplication openURL:[NSURL URLWithString:url] options:@{} completionHandler:nil];
             }],
+        [UIAction
+            actionWithTitle:@"Add to Home Screen"
+            image:[UIImage systemImageNamed:@"square.and.arrow.down"]
+            identifier: nil
+            handler:^(UIAction *action) {
+            if ([[NSUserDefaults.standardUserDefaults stringForKey:@"shortcutAdded"] isEqualToString:@"true"]) {
+                NSData *imageData = UIImagePNGRepresentation([[appInfo icon] _imageWithSize:CGSizeMake(60, 60)]);
+                NSString *base64Image = [imageData base64EncodedStringWithOptions:0];
+                NSData *share = [[NSString stringWithFormat:@"{\"name\":\"%@\",\"image\":\"%@\"}", [appInfo displayName], base64Image] dataUsingEncoding:NSUTF8StringEncoding];
+                [UIApplication.sharedApplication openURL: [NSURL URLWithString:[NSString stringWithFormat:@"shortcuts://run-shortcut?name=LiveContainerHelper&input=%@", [share base64EncodedStringWithOptions:0]]] options:@{} completionHandler:nil];
+            } else {
+                [self showDialogTitle:@"Install Helper Shortcut" message:@"You need to install the helper shortcut in the Settings tab"];
+            }
+        }],
         [self
             destructiveActionWithTitle:@"Reset settings"
             image:[UIImage systemImageNamed:@"trash"]
@@ -651,6 +665,7 @@ static void patchExecSlice(const char *path, struct mach_header_64 *header) {
             }]
     ];
 
+    
     return [UIContextMenuConfiguration
         configurationWithIdentifier:nil
         previewProvider:nil

--- a/LCSettingsListController.m
+++ b/LCSettingsListController.m
@@ -24,6 +24,18 @@
         [signTweaksButton setProperty:@(!!LCUtils.certificateData) forKey:@"enabled"];
         signTweaksButton.buttonAction = @selector(signTweaksPressed);
         [_specifiers addObject:signTweaksButton];
+        
+        PSSpecifier* addToHomeScreenGroup = [PSSpecifier emptyGroupSpecifier];
+        addToHomeScreenGroup.name = @"Helper Shortcut";
+        [addToHomeScreenGroup setProperty:@"The helper shortcut allows you to add apps from LiveContainer to your homescreen. Requires Apple Shortcuts." forKey:@"footerText"];
+        [_specifiers addObject:addToHomeScreenGroup];
+        
+        NSString *setupHelperShortcutButtonName = [[NSUserDefaults.standardUserDefaults stringForKey:@"shortcutAdded"] isEqualToString:@"true"] ? @"Shortcut added" : @"Add Helper Shortcut";
+        PSSpecifier* setupHelperShortcutButton = [PSSpecifier preferenceSpecifierNamed:setupHelperShortcutButtonName target:self set:nil get:nil detail:nil cell:PSButtonCell edit:nil];
+        setupHelperShortcutButton.identifier = @"setup-helper-shortcut";
+        [setupHelperShortcutButton setProperty:@(![[NSUserDefaults.standardUserDefaults stringForKey:@"shortcutAdded"] isEqualToString:@"true"]) forKey:@"enabled"];
+        setupHelperShortcutButton.buttonAction = @selector(setupHelperShortcutPressed);
+        [_specifiers addObject:setupHelperShortcutButton];
     }
     return _specifiers;
 }
@@ -42,6 +54,14 @@
     }
 
     [UIApplication.sharedApplication openURL:[NSURL URLWithString:[NSString stringWithFormat:@"sidestore://install?url=%@", url]] options:@{} completionHandler:nil];
+}
+
+- (void)setupHelperShortcutPressed {
+    NSURL *url = [NSURL URLWithString:@"https://www.icloud.com/shortcuts/587beaf7856c4a3699ba479c14f9ada1"];
+    [UIApplication.sharedApplication openURL:url options:@{} completionHandler: ^(BOOL b) {
+        [NSUserDefaults.standardUserDefaults setObject:@"true" forKey:@"shortcutAdded"];
+        exit(0);
+    }];
 }
 
 - (void)signTweaksPressed {


### PR DESCRIPTION
Using a helper shortcut (to generate web clips) as well as a url scheme, it is made possible to add apps to home screen.

Next launched app is configured using `livecontainer://launchapp?exec=[app name percent encoded].app`, then the app can be launched normally.

The helper shortcut (integrated into the app in the settings tab) automates the launching of the app, and the adding of the app to the homescreen (located here: https://www.icloud.com/shortcuts/f777072dfe4d48ada1004c496f76154f)

Solves #61 

(please excuse my awful objc code, this is my first time using objective c)