### PR TITLE
Allow "Open In App" for Apps inside LiveContainer & Remove Data Folder after Uninstalling

### DIFF
--- a/LCSharedUtils.h
+++ b/LCSharedUtils.h
@@ -5,5 +5,5 @@
 + (NSString *)certificatePassword;
 + (BOOL)launchToGuestApp;
 + (BOOL)launchToGuestAppWithURL:(NSURL *)url;
-
++ (void)setWebPageUrlForNextLaunch:(NSString*)urlString;
 @end

--- a/LCSharedUtils.m
+++ b/LCSharedUtils.m
@@ -49,4 +49,8 @@ extern NSUserDefaults *lcUserDefaults;
     return NO;
 }
 
++ (void)setWebPageUrlForNextLaunch:(NSString*) urlString {
+    [lcUserDefaults setObject:urlString forKey:@"webPageToOpen"];
+}
+
 @end

--- a/LiveContainerUI/LCAppDelegate.m
+++ b/LiveContainerUI/LCAppDelegate.m
@@ -21,8 +21,7 @@
 }
 
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
-    NSLog(@"[LiveContainer]got url to open: %@", url);
-    NSLog(@"[LiveContainer]host: %@", url.host);
+    // handle page open request from URL scheme
     if([url.host isEqualToString:@"open-web-page"]) {
         NSURLComponents* urlComponent = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
         if(urlComponent.queryItems.count == 0){
@@ -31,7 +30,6 @@
         
         NSData *decodedData = [[NSData alloc] initWithBase64EncodedString:urlComponent.queryItems[0].value options:0];
         NSString *decodedUrl = [[NSString alloc] initWithData:decodedData encoding:NSUTF8StringEncoding];
-        NSLog(@"[LiveContainer]Webpage to open: %@", decodedUrl);
         [((LCTabBarController*)_rootViewController) openWebPage:decodedUrl];
     }
     return [LCUtils launchToGuestAppWithURL:url];

--- a/LiveContainerUI/LCAppDelegate.m
+++ b/LiveContainerUI/LCAppDelegate.m
@@ -2,6 +2,7 @@
 #import "LCJITLessSetupViewController.h"
 #import "LCTabBarController.h"
 #import "LCUtils.h"
+#import <UIKit/UIKit.h>
 
 @implementation LCAppDelegate
 
@@ -20,6 +21,19 @@
 }
 
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+    NSLog(@"[LiveContainer]got url to open: %@", url);
+    NSLog(@"[LiveContainer]host: %@", url.host);
+    if([url.host isEqualToString:@"open-web-page"]) {
+        NSURLComponents* urlComponent = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+        if(urlComponent.queryItems.count == 0){
+            return YES;
+        }
+        
+        NSData *decodedData = [[NSData alloc] initWithBase64EncodedString:urlComponent.queryItems[0].value options:0];
+        NSString *decodedUrl = [[NSString alloc] initWithData:decodedData encoding:NSUTF8StringEncoding];
+        NSLog(@"[LiveContainer]Webpage to open: %@", decodedUrl);
+        [((LCTabBarController*)_rootViewController) openWebPage:decodedUrl];
+    }
     return [LCUtils launchToGuestAppWithURL:url];
 }
 

--- a/LiveContainerUI/LCAppInfo.h
+++ b/LiveContainerUI/LCAppInfo.h
@@ -14,6 +14,7 @@
 - (NSString*)version;
 - (NSString*)dataUUID;
 - (NSString*)tweakFolder;
+@property NSMutableArray* urlSchemes;
 - (void)setDataUUID:(NSString *)uuid;
 - (void)setTweakFolder:(NSString *)tweakFolder;
 - (instancetype)initWithBundlePath:(NSString*)bundlePath;

--- a/LiveContainerUI/LCAppInfo.h
+++ b/LiveContainerUI/LCAppInfo.h
@@ -5,7 +5,7 @@
    NSMutableDictionary* _info;
    NSString* _bundlePath;
 }
-
+@property NSString* relativeBundlePath;
 - (NSMutableDictionary*)info;
 - (UIImage*)icon;
 - (NSString*)displayName;
@@ -14,7 +14,7 @@
 - (NSString*)version;
 - (NSString*)dataUUID;
 - (NSString*)tweakFolder;
-@property NSMutableArray* urlSchemes;
+- (NSMutableArray*) urlSchemes;
 - (void)setDataUUID:(NSString *)uuid;
 - (void)setTweakFolder:(NSString *)tweakFolder;
 - (instancetype)initWithBundlePath:(NSString*)bundlePath;

--- a/LiveContainerUI/LCAppInfo.m
+++ b/LiveContainerUI/LCAppInfo.m
@@ -5,30 +5,36 @@
 @implementation LCAppInfo
 - (instancetype)initWithBundlePath:(NSString*)bundlePath {
 	 self = [super init];
-    self.urlSchemes = [[NSMutableArray alloc] init];
+    
 	 if(self) {
         _bundlePath = bundlePath;
         _info = [NSMutableDictionary dictionaryWithContentsOfFile:[NSString stringWithFormat:@"%@/Info.plist", bundlePath]];
-         
-         // find all url schemes
-         int nowSchemeCount = 0;
-         if (_info[@"CFBundleURLTypes"]) {
-             NSMutableArray* urlTypes = _info[@"CFBundleURLTypes"];
-
-             for(int i = 0; i < [urlTypes count]; ++i) {
-                 NSMutableDictionary* nowUrlType = [urlTypes objectAtIndex:i];
-                 if (!nowUrlType[@"CFBundleURLSchemes"]){
-                     continue;
-                 }
-                 NSMutableArray *schemes = nowUrlType[@"CFBundleURLSchemes"];
-                 for(int j = 0; j < [schemes count]; ++j) {
-                     [self.urlSchemes insertObject:[schemes objectAtIndex:j] atIndex:nowSchemeCount];
-                     ++nowSchemeCount;
-                 }
-             }
-         }
+        
     }
     return self;
+}
+
+- (NSMutableArray*)urlSchemes {
+    // find all url schemes
+    NSMutableArray* urlSchemes = [[NSMutableArray alloc] init];
+    int nowSchemeCount = 0;
+    if (_info[@"CFBundleURLTypes"]) {
+        NSMutableArray* urlTypes = _info[@"CFBundleURLTypes"];
+
+        for(int i = 0; i < [urlTypes count]; ++i) {
+            NSMutableDictionary* nowUrlType = [urlTypes objectAtIndex:i];
+            if (!nowUrlType[@"CFBundleURLSchemes"]){
+                continue;
+            }
+            NSMutableArray *schemes = nowUrlType[@"CFBundleURLSchemes"];
+            for(int j = 0; j < [schemes count]; ++j) {
+                [urlSchemes insertObject:[schemes objectAtIndex:j] atIndex:nowSchemeCount];
+                ++nowSchemeCount;
+            }
+        }
+    }
+    
+    return urlSchemes;
 }
 
 - (NSString*)displayName {

--- a/LiveContainerUI/LCAppInfo.m
+++ b/LiveContainerUI/LCAppInfo.m
@@ -5,9 +5,28 @@
 @implementation LCAppInfo
 - (instancetype)initWithBundlePath:(NSString*)bundlePath {
 	 self = [super init];
+    self.urlSchemes = [[NSMutableArray alloc] init];
 	 if(self) {
         _bundlePath = bundlePath;
         _info = [NSMutableDictionary dictionaryWithContentsOfFile:[NSString stringWithFormat:@"%@/Info.plist", bundlePath]];
+         
+         // find all url schemes
+         int nowSchemeCount = 0;
+         if (_info[@"CFBundleURLTypes"]) {
+             NSMutableArray* urlTypes = _info[@"CFBundleURLTypes"];
+
+             for(int i = 0; i < [urlTypes count]; ++i) {
+                 NSMutableDictionary* nowUrlType = [urlTypes objectAtIndex:i];
+                 if (!nowUrlType[@"CFBundleURLSchemes"]){
+                     continue;
+                 }
+                 NSMutableArray *schemes = nowUrlType[@"CFBundleURLSchemes"];
+                 for(int j = 0; j < [schemes count]; ++j) {
+                     [self.urlSchemes insertObject:[schemes objectAtIndex:j] atIndex:nowSchemeCount];
+                     ++nowSchemeCount;
+                 }
+             }
+         }
     }
     return self;
 }

--- a/LiveContainerUI/LCAppListViewController.h
+++ b/LiveContainerUI/LCAppListViewController.h
@@ -2,4 +2,5 @@
 
 @interface LCAppListViewController : UITableViewController <UIDocumentPickerDelegate>
 @property(nonatomic) NSString* acError;
+- (void) openWebViewByURLString:(NSString*) urlString;
 @end

--- a/LiveContainerUI/LCAppListViewController.m
+++ b/LiveContainerUI/LCAppListViewController.m
@@ -24,6 +24,8 @@
 @property(nonatomic) NSString *bundlePath, *docPath, *tweakPath;
 
 @property(nonatomic) MBRoundProgressView *progressView;
+
+@property(nonatomic) UIButton *openLinkButton;
 @end
 
 @implementation LCAppListViewController
@@ -55,6 +57,16 @@
     self.navigationItem.rightBarButtonItems = @[
         [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemPlay target:self action:@selector(launchButtonTapped)],
         [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAdd target:self action:@selector(addButtonTapped)]
+    ];
+    
+    UIButton* openLinkButton = [UIButton buttonWithType:UIButtonTypeCustom];
+    openLinkButton.enabled = !!LCUtils.certificatePassword;
+    openLinkButton.frame = CGRectMake(0, 0, 40, 40);
+    [openLinkButton setImage:[UIImage systemImageNamed:@"link"] forState:UIControlStateNormal];
+    [openLinkButton addTarget:self action:@selector(openUrlButtonTapped) forControlEvents:UIControlEventTouchUpInside];
+
+    self.navigationItem.leftBarButtonItems = @[
+        [[UIBarButtonItem alloc] initWithCustomView:openLinkButton]
     ];
 
     self.progressView = [[MBRoundProgressView alloc] initWithFrame:CGRectMake(0, 0, 60, 60)];
@@ -613,6 +625,25 @@ trailingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath {
         options:UIMenuOptionsDestructive
         children:@[confirmAction]];
     return menu;
+}
+
+
+- (void) openUrlButtonTapped {
+    [self showInputDialogTitle:@"Input URL" message:@"Input URL scheme or URL to a web page" placeholder:@"scheme://" callback:^(NSString *ans) {
+        NSLog(@"[LiveContainer] got url: %@", ans);
+        NSURL* url = [NSURL URLWithString: ans];
+        dispatch_async(dispatch_get_main_queue(), ^(void){
+            if(!url) {
+                [self showDialogTitle:@"Invalid URL" message:@"The given URL is invalid. Check it and try again."];
+            } else {
+                [self showDialogTitle:@"Valid URL" message: @"Good."];
+            }
+        });
+        return (NSString*)nil;
+    }];
+
+
+    
 }
 
 @end

--- a/LiveContainerUI/LCAppListViewController.m
+++ b/LiveContainerUI/LCAppListViewController.m
@@ -324,6 +324,20 @@
             } else {
                 [self.objects removeObjectAtIndex:indexPath.row];
                 [self.tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+                [self showConfirmationDialogTitle:@"Delete Data Folder"
+                message:[NSString stringWithFormat:@"Do you also want to delete data folder of %@? You can keep it for future use.", appInfo.displayName]
+                destructive:YES
+                confirmButtonTitle:@"Delete"
+                handler:^(UIAlertAction * action) {
+                    if (action.style != UIAlertActionStyleCancel) {
+                        NSError *error = nil;
+                        NSString* dataFolderPath = [NSString stringWithFormat:@"%@/Data/Application/%@", self.docPath, [appInfo dataUUID]];
+                        [NSFileManager.defaultManager removeItemAtPath:dataFolderPath error:&error];
+                        if (error) {
+                            [self showDialogTitle:@"Error" message:error.localizedDescription];
+                        }
+                    }
+                }];
             }
         }
         handler(YES);

--- a/LiveContainerUI/LCAppListViewController.m
+++ b/LiveContainerUI/LCAppListViewController.m
@@ -681,9 +681,9 @@ trailingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath {
         }
         
         // use https for http and empty scheme
-        if([url.scheme length ] == 0 || [url.scheme isEqualToString:@"http"]) {
+        if([url.scheme length ] == 0) {
             url.scheme = @"https";
-        } else if (![url.scheme isEqualToString: @"https"]){
+        } else if (![url.scheme isEqualToString: @"https"] && ![url.scheme isEqualToString: @"http"]){
             [self launchAppByScheme:url apps:apps];
         }
         LCWebView *webViewController = [[LCWebView alloc] initWithURL:url.URL apps:apps];

--- a/LiveContainerUI/LCAppListViewController.m
+++ b/LiveContainerUI/LCAppListViewController.m
@@ -23,7 +23,7 @@
 @interface LCAppListViewController ()
 @property(atomic) NSMutableArray<NSString *> *objects;
 @property(nonatomic) NSString *bundlePath, *docPath, *tweakPath;
-
+@property(atomic) NSString* pageUrlToOpen;
 @property(nonatomic) MBRoundProgressView *progressView;
 
 @end
@@ -70,6 +70,10 @@
     ];
 
     self.progressView = [[MBRoundProgressView alloc] initWithFrame:CGRectMake(0, 0, 60, 60)];
+    if(self.pageUrlToOpen) {
+        [self openWebViewByURLString:self.pageUrlToOpen];
+        self.pageUrlToOpen = nil;
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -645,6 +649,12 @@ trailingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath {
 }
 
 - (void) openWebViewByURLString:(NSString*) urlString {
+    // wait for the loadView to call again.
+    if(!self.isViewLoaded) {
+        self.pageUrlToOpen = urlString;
+        return;
+    }
+    
     NSURLComponents* url = [[NSURLComponents alloc] initWithString:urlString];
     if(!url) {
         [self showDialogTitle:@"Invalid URL" message:@"The given URL is invalid. Check it and try again."];

--- a/LiveContainerUI/LCTabBarController.h
+++ b/LiveContainerUI/LCTabBarController.h
@@ -1,4 +1,7 @@
 #import <UIKit/UIKit.h>
+#import "LCAppListViewController.h"
 
 @interface LCTabBarController : UITabBarController
+@property() LCAppListViewController* appTableVC;
+- (void) openWebPage:(NSString*) urlString;
 @end

--- a/LiveContainerUI/LCTabBarController.m
+++ b/LiveContainerUI/LCTabBarController.m
@@ -1,4 +1,3 @@
-#import "LCAppListViewController.h"
 #import "LCSettingsListController.h"
 #import "LCTweakListViewController.h"
 #import "LCTabBarController.h"
@@ -10,6 +9,7 @@
 
     LCAppListViewController* appTableVC = [LCAppListViewController new];
     appTableVC.title = @"Apps";
+    self.appTableVC = appTableVC;
 
     LCTweakListViewController* tweakTableVC = [LCTweakListViewController new];
     tweakTableVC.title = @"Tweaks";
@@ -26,6 +26,10 @@
     settingsNavigationController.tabBarItem.image = [UIImage systemImageNamed:@"gear"];
 
     self.viewControllers = @[appNavigationController, tweakNavigationController, settingsNavigationController];
+}
+
+- (void) openWebPage:(NSString*) urlString {
+    [self.appTableVC openWebViewByURLString:urlString];
 }
 
 @end

--- a/LiveContainerUI/LCWebView.h
+++ b/LiveContainerUI/LCWebView.h
@@ -1,0 +1,11 @@
+#import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
+#import "LCAppInfo.h"
+
+@interface LCWebView : UIViewController <WKNavigationDelegate>
+- (instancetype)initWithURL:(NSURL *)url apps:(NSMutableArray<LCAppInfo*>*)apps;
+- (void)askIfLaunchApp:(NSString*)appId url:(NSURL*)launchUrl;
+@property (nonatomic) NSURL *url;
+@property (nonatomic) NSMutableArray<LCAppInfo*>* apps;
+@property (strong, nonatomic) WKWebView *webView;
+@end

--- a/LiveContainerUI/LCWebview.m
+++ b/LiveContainerUI/LCWebview.m
@@ -1,0 +1,150 @@
+//
+//  LCWebview.m
+//  jump
+//
+//  Created by s s on 2024/8/18.
+//
+
+
+#import "LCWebView.h"
+#import "LCUtils.h"
+
+@interface MySchemeHandler : NSObject<WKURLSchemeHandler>
+- (instancetype)initWithApp:(NSString*)appId viewController:(LCWebView*)lcController;
+@property NSString* appId;
+@property LCWebView* lcController;
+@end
+
+@implementation MySchemeHandler
+
+- (instancetype)initWithApp:(NSString*)appId viewController:(LCWebView*)lcController{
+    self = [super init];
+    self.appId = appId;
+    self.lcController = lcController;
+    return self;
+}
+
+- (void)webView:(nonnull WKWebView *)webView startURLSchemeTask:(nonnull id<WKURLSchemeTask>)urlSchemeTask {
+    [self.lcController askIfLaunchApp:self.appId url: urlSchemeTask.request.URL];
+}
+
+- (void)webView:(nonnull WKWebView *)webView stopURLSchemeTask:(nonnull id<WKURLSchemeTask>)urlSchemeTask {
+    NSLog(@"stopURLScheme");
+}
+
+@end
+
+
+
+@implementation LCWebView
+
+- (instancetype)initWithURL:(NSURL *)url apps:(NSMutableArray<LCAppInfo*>*)apps {
+    self = [super init];  // Call the superclass's init method
+    if (self) {
+        self.apps = apps;
+        self.url = url;  // Store the URL string
+        
+    }
+    return self;
+}
+
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    if (!self.webView.superview) {
+        WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+        
+
+        CGRect webViewSize = self.view.bounds;
+        webViewSize.size.height -= self.navigationController.navigationBar.frame.size.height;
+        webViewSize.size.height -= [self.view.window.windowScene.statusBarManager statusBarFrame].size.height;
+        webViewSize.size.height -= 30;
+        self.webView = [[WKWebView alloc] initWithFrame:webViewSize configuration:config];
+        self.webView.navigationDelegate = self;
+        self.webView.customUserAgent = @"Mozilla/5.0 (iPhone; CPU iPhone OS 17_6_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Mobile/15E148 Safari/604.1";
+        [self.view addSubview:self.webView];
+    }
+    UIBarButtonItem *backButton = [[UIBarButtonItem alloc] initWithImage:[UIImage systemImageNamed:@"chevron.backward"] style:UIBarButtonItemStylePlain target:self action:@selector(goBack)];
+    UIBarButtonItem *forwardButton = [[UIBarButtonItem alloc] initWithImage:[UIImage systemImageNamed:@"chevron.forward"] style:UIBarButtonItemStylePlain target:self action:@selector(goForward)];
+    self.navigationItem.leftBarButtonItems = @[backButton, forwardButton];
+    
+    // Add a refresh button on the right
+    UIBarButtonItem *refreshButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemRefresh target:self action:@selector(reloadWebView)];
+    UIBarButtonItem *closeButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(close)];
+    self.navigationItem.rightBarButtonItems = @[closeButton, refreshButton];
+    
+    // Load the webpage passed via the initializer
+    if (self.url) {
+        NSURLRequest *request = [NSURLRequest requestWithURL:self.url];
+        [self.webView loadRequest:request];
+    }
+}
+
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
+    self.title = webView.title;
+}
+
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
+    // use private API, get rid of Universal link
+    decisionHandler((WKNavigationActionPolicy)(WKNavigationActionPolicyAllow + 2));
+    NSString* scheme = navigationAction.request.URL.scheme;
+    if([scheme length] == 0 || [scheme isEqualToString:@"https"] || [scheme isEqualToString:@"http"] || [scheme isEqualToString:@"about"] || [scheme isEqualToString:@"itms-appss"]) {
+        return;
+    }
+    // add a unique urlHandler for each app
+    LCAppInfo* appToOpen = nil;
+    for(int i = 0; i < [self.apps count] && !appToOpen; ++i) {
+        LCAppInfo* nowAppInfo = self.apps[i];
+        NSMutableArray* schemes = [nowAppInfo urlSchemes];
+        if(!schemes) continue;
+        for(int j = 0; j < [schemes count]; ++j) {
+            if([scheme isEqualToString:schemes[j]]) {
+                appToOpen = nowAppInfo;
+                break;
+            }
+        }
+    }
+    if(!appToOpen){
+        return;
+    }
+    [self askIfLaunchApp:appToOpen.relativeBundlePath url:navigationAction.request.URL];
+}
+
+- (void)goBack {
+    if ([self.webView canGoBack]) {
+        [self.webView goBack];
+    }
+}
+
+- (void)goForward {
+    if ([self.webView canGoForward]) {
+        [self.webView goForward];
+    }
+}
+
+- (void)reloadWebView {
+    [self.webView reload];
+}
+
+- (void)close {
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)askIfLaunchApp:(NSString*)appId url:(NSURL*)launchUrl {
+    NSString* message = [NSString stringWithFormat:@"This web page is trying to launch %@, continue?", appId];
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"LiveContainer" message:message preferredStyle:UIAlertControllerStyleAlert];
+    UIAlertAction* okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
+        [NSUserDefaults.standardUserDefaults setObject:appId forKey:@"selected"];
+        [NSUserDefaults.standardUserDefaults setObject:launchUrl.absoluteString forKey:@"launchAppUrlScheme"];
+        if ([LCUtils launchToGuestApp]) return;
+    }];
+    [alert addAction:okAction];
+    UIAlertAction* cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {
+        
+    }];
+    [alert addAction:cancelAction];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+@end

--- a/LiveContainerUI/Makefile
+++ b/LiveContainerUI/Makefile
@@ -2,7 +2,7 @@ include $(THEOS)/makefiles/common.mk
 
 FRAMEWORK_NAME = LiveContainerUI
 
-LiveContainerUI_FILES = LCAppDelegate.m LCJITLessSetupViewController.m LCMachOUtils.m LCAppListViewController.m LCSettingsListController.m LCTabBarController.m LCTweakListViewController.m LCUtils.m MBRoundProgressView.m UIViewController+LCAlert.m unarchive.m LCAppInfo.m
+LiveContainerUI_FILES = LCAppDelegate.m LCJITLessSetupViewController.m LCMachOUtils.m LCAppListViewController.m LCSettingsListController.m LCTabBarController.m LCTweakListViewController.m LCUtils.m MBRoundProgressView.m UIViewController+LCAlert.m unarchive.m LCAppInfo.m LCWebView.m
 LiveContainerUI_CFLAGS = \
   -fobjc-arc \
   -DCONFIG_TYPE=\"$(CONFIG_TYPE)\" \

--- a/TweakLoader/UIKit+GuestHooks.m
+++ b/TweakLoader/UIKit+GuestHooks.m
@@ -120,37 +120,38 @@ void LCOpenWebPage(NSString* webPageUrlString) {
     NSString *url = urlAction.url.absoluteString;
     if ([url hasPrefix:@"livecontainer://livecontainer-relaunch"]) {
         // Ignore
-        return;
+        
     } else if ([url hasPrefix:@"livecontainer://open-web-page?"]) {
         NSURLComponents* lcUrl = [NSURLComponents componentsWithString:url];
         NSString* realUrlEncoded = lcUrl.queryItems[0].value;
-        if(!realUrlEncoded) return;
-        // launch to UI and open web page
-        NSData *decodedData = [[NSData alloc] initWithBase64EncodedString:realUrlEncoded options:0];
-        NSString *decodedUrl = [[NSString alloc] initWithData:decodedData encoding:NSUTF8StringEncoding];
-        LCOpenWebPage(decodedUrl);
-        return;
+        if(realUrlEncoded) {
+            // launch to UI and open web page
+            NSData *decodedData = [[NSData alloc] initWithBase64EncodedString:realUrlEncoded options:0];
+            NSString *decodedUrl = [[NSString alloc] initWithData:decodedData encoding:NSUTF8StringEncoding];
+            LCOpenWebPage(decodedUrl);
+        }
+
     } else if ([url hasPrefix:@"livecontainer://open-url?"]) {
         // Open guest app's URL scheme
         NSURLComponents* lcUrl = [NSURLComponents componentsWithString:url];
         NSString* realUrlEncoded = lcUrl.queryItems[0].value;
-        if(!realUrlEncoded) return;
-        // Convert the base64 encoded url into String
-        NSData *decodedData = [[NSData alloc] initWithBase64EncodedString:realUrlEncoded options:0];
-        NSString *decodedUrl = [[NSString alloc] initWithData:decodedData encoding:NSUTF8StringEncoding];
-        
-        NSMutableSet *newActions = actions.mutableCopy;
-        [newActions removeObject:urlAction];
-        UIOpenURLAction *newUrlAction = [[UIOpenURLAction alloc] initWithURL:[NSURL URLWithString:decodedUrl]];
-        [newActions addObject:newUrlAction];
-        [self hook_scene:scene didReceiveActions:newActions fromTransitionContext:context];
-        return;
+        if(realUrlEncoded) {
+            // Convert the base64 encoded url into String
+            NSData *decodedData = [[NSData alloc] initWithBase64EncodedString:realUrlEncoded options:0];
+            NSString *decodedUrl = [[NSString alloc] initWithData:decodedData encoding:NSUTF8StringEncoding];
+            
+            NSMutableSet *newActions = actions.mutableCopy;
+            [newActions removeObject:urlAction];
+            UIOpenURLAction *newUrlAction = [[UIOpenURLAction alloc] initWithURL:[NSURL URLWithString:decodedUrl]];
+            [newActions addObject:newUrlAction];
+            [self hook_scene:scene didReceiveActions:newActions fromTransitionContext:context];
+            return;
+        }
     } else if ([url hasPrefix:@"livecontainer://livecontainer-launch?"]){
         // If it's not current app, then switch
         if (![url hasSuffix:NSBundle.mainBundle.bundlePath.lastPathComponent]) {
             LCShowSwitchAppConfirmation(urlAction.url);
         }
-        return;
         
     }
 

--- a/UIKitPrivate.h
+++ b/UIKitPrivate.h
@@ -31,6 +31,7 @@
 
 @interface UIOpenURLAction : NSObject
 - (NSURL *)url;
+- (instancetype)initWithURL:(NSURL *)arg1;
 @end
 
 @interface UITableViewHeaderFooterView(private)


### PR DESCRIPTION
I sometimes need to open a link to an app inside LiveContainer, a Spotify album for example, and it's a pain that "Open In App" button doesn't work for apps inside LiveContainer. https://github.com/khanhduytran0/LiveContainer/issues/119

In this PR, I implemented the feature that users can share a Safari page or link to LiveContainer. LiveContainer will open a WKWebView to show these pages and users can click "Open In App" button to open specific apps inside LiveContainer. LiveContainer will intercept that navigation, open the specific app and pass URL scheme to that app.

What's more, I added a link button on the top left corner so users can manually input the URL of a web page or a URL scheme.

I made a Shortcut to accomplish the Safari sharing feature, you can download and have a try: https://www.icloud.com/shortcuts/44ea82ce7ed8469ea24198c375db09a0

P.S. I'm pretty new to Objc so please forgive my dumb code